### PR TITLE
CC-3228 service code owners

### DIFF
--- a/src/main/java/uk/gov/companieshouse/servicesdashboardapi/model/github/GitInfo.java
+++ b/src/main/java/uk/gov/companieshouse/servicesdashboardapi/model/github/GitInfo.java
@@ -68,23 +68,25 @@ public class GitInfo {
    //    "ecs-service-1.0.20"  |
    private List<GitReleaseInfo> filterReleases(List<GitReleaseInfo> gitReleases) {
         List<GitReleaseInfo> rel = new ArrayList<GitReleaseInfo>();
-        if (! gitReleases.isEmpty()) {
-            GitReleaseInfo firstRelease = gitReleases.get(0);
-            rel.add(firstRelease);
 
-            String regexPattern = buildRegexPattern(firstRelease.getVersion());
-            // System.out.println("Generated Regex: " + regexPattern);
+        if (gitReleases.isEmpty()) {
+            return rel;
+        }
 
-            Pattern pattern = Pattern.compile(regexPattern);
+        GitReleaseInfo firstRelease = gitReleases.get(0);
+        rel.add(firstRelease);
 
-            // The built regex are generic and could potentially match more random strings
-            // ex the regex from v1.177.0-rc3" matches something like "Z1876545.22222.564-LL99999"
-            // but that's ok considering that our GitHub releases' format is consistent
-            for (GitReleaseInfo r : gitReleases) {
-                if (!pattern.matcher(r.getVersion()).matches()) {
-                    rel.add(r); // Add any optional different format and then break. (We'll then have max 2 releases)
-                    break;
-                }
+        String regexPattern = buildRegexPattern(firstRelease.getVersion());
+
+        Pattern pattern = Pattern.compile(regexPattern);
+
+        // The built regex are generic and could potentially match more random strings
+        // ex the regex from v1.177.0-rc3" matches something like "Z1876545.22222.564-LL99999"
+        // but that's ok considering that our GitHub releases' format is consistent
+        for (GitReleaseInfo r : gitReleases) {
+            if (!pattern.matcher(r.getVersion()).matches()) {
+                rel.add(r); // Add any optional different format and then break. (We'll then have max 2 releases)
+                break;
             }
         }
         return rel;

--- a/src/main/java/uk/gov/companieshouse/servicesdashboardapi/model/github/GitInfo.java
+++ b/src/main/java/uk/gov/companieshouse/servicesdashboardapi/model/github/GitInfo.java
@@ -2,7 +2,8 @@ package uk.gov.companieshouse.servicesdashboardapi.model.github;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.*;
+import uk.gov.companieshouse.servicesdashboardapi.utils.GitUtils;
+
 public class GitInfo {
 
    private String repo;
@@ -49,77 +50,12 @@ public class GitInfo {
    }
 
    public void setReleases(List<GitReleaseInfo> gitReleases) {
-      this.releases = gitReleases.isEmpty() ? new ArrayList<>() : filterReleases(gitReleases);
+      this.releases = gitReleases.isEmpty() ? new ArrayList<>() : GitUtils.filterReleases(gitReleases);
    }
 
    @Override
    public String toString() {
       return String.format("{r:%s l:%s o:%s sA:%s [R:%s]}", repo, lang, owner, serviceArea, (releases == null || releases.isEmpty()) ? "unknown" : releases.toString());
    }
-
-
-   // Filter out the 2 latest releases that are not part of the same release cycle
-   // ex.
-   //    "ecs-service-1.0.22"  |
-   //    "ecs-service-1.0.21"  |
-   //    "ecs-service-1.0.20"  |-----> "ecs-service-1.0.22"
-   //    "4.0.11"              |       "4.0.11"
-   //    "4.0.10"              |
-   //    "ecs-service-1.0.20"  |
-   private List<GitReleaseInfo> filterReleases(List<GitReleaseInfo> gitReleases) {
-        List<GitReleaseInfo> rel = new ArrayList<GitReleaseInfo>();
-
-        if (gitReleases.isEmpty()) {
-            return rel;
-        }
-
-        GitReleaseInfo firstRelease = gitReleases.get(0);
-        rel.add(firstRelease);
-
-        String regexPattern = buildRegexPattern(firstRelease.getVersion());
-
-        Pattern pattern = Pattern.compile(regexPattern);
-
-        // The built regex are generic and could potentially match more random strings
-        // ex the regex from v1.177.0-rc3" matches something like "Z1876545.22222.564-LL99999"
-        // but that's ok considering that our GitHub releases' format is consistent
-        for (GitReleaseInfo r : gitReleases) {
-            if (!pattern.matcher(r.getVersion()).matches()) {
-                rel.add(r); // Add any optional different format and then break. (We'll then have max 2 releases)
-                break;
-            }
-        }
-        return rel;
-    }
-
-    // build a regex from a provided Release string
-    // ex:
-    // "v1.177.0-rc3"       --> [a-zA-Z]\d+\.\d+\.\d+\-[a-zA-Z][a-zA-Z]\d+])
-    // "5.17.0"             --> \d+\.\d+\.\d+
-    // "ecs-service-1.0.22" --> [a-zA-Z][a-zA-Z][a-zA-Z]\-[a-zA-Z][a-zA-Z][a-zA-Z][a-zA-Z][a-zA-Z][a-zA-Z][a-zA-Z]\-\d+\.\d+\.\d+
-
-    private static String buildRegexPattern(String example) {
-        StringBuilder regex = new StringBuilder();
-        boolean inNumber = false; // Flag to track digit sequences
-
-        for (int i = 0; i < example.length(); i++) {
-            char c = example.charAt(i);
-
-            if (Character.isLetter(c)) {
-                regex.append("[a-zA-Z]");
-                inNumber = false; // Reset number flag
-            } else if (Character.isDigit(c)) {
-                if (!inNumber) { // Only append \d+ for the first digit in a sequence
-                    regex.append("\\d+");
-                    inNumber = true;
-                }
-            } else {
-                regex.append("\\").append(c); // Escape special characters
-                inNumber = false; // Reset number flag
-            }
-        }
-
-        return regex.toString();
-    }
 }
 

--- a/src/main/java/uk/gov/companieshouse/servicesdashboardapi/model/github/GitInfo.java
+++ b/src/main/java/uk/gov/companieshouse/servicesdashboardapi/model/github/GitInfo.java
@@ -8,6 +8,7 @@ public class GitInfo {
    private String repo;
    private String lang;
    private String owner;
+   private String serviceArea;
    private List<GitReleaseInfo> releases;
 
    // Getters and Setters
@@ -31,6 +32,14 @@ public class GitInfo {
       this.owner = owner;
    }
 
+   public String getServiceArea() {
+      return serviceArea;
+   }
+
+   public void setServiceArea(String serviceArea) {
+      this.serviceArea = serviceArea;
+   }
+
    public void setLang(String lang) {
       this.lang = lang;
    }
@@ -45,7 +54,7 @@ public class GitInfo {
 
    @Override
    public String toString() {
-      return String.format("{r:%s l:%s o:%s [R:%s]}", repo, lang, owner, (releases == null || releases.isEmpty()) ? "unknown" : releases.toString());
+      return String.format("{r:%s l:%s o:%s sA:%s [R:%s]}", repo, lang, owner, serviceArea, (releases == null || releases.isEmpty()) ? "unknown" : releases.toString());
    }
 
 

--- a/src/main/java/uk/gov/companieshouse/servicesdashboardapi/model/merge/ProjectInfo.java
+++ b/src/main/java/uk/gov/companieshouse/servicesdashboardapi/model/merge/ProjectInfo.java
@@ -2,7 +2,6 @@ package uk.gov.companieshouse.servicesdashboardapi.model.merge;
 
 import java.util.List;
 import java.util.Map;
-// import java.util.Set;
 
 import uk.gov.companieshouse.servicesdashboardapi.model.github.GitInfo;
 
@@ -13,7 +12,6 @@ public class ProjectInfo {
    private String sonarKey;
    private Map<String, Integer> sonarMetrics;
    private GitInfo gitInfo;
-   // private Map<String, Set<String>> ecs;
 
 
    // Getters and setters
@@ -60,14 +58,6 @@ public class ProjectInfo {
    public void setGitInfo(GitInfo gitInfo) {
       this.gitInfo = gitInfo;
    }
-
-   // public Map<String, Set<String>> getEcs() {
-   //    return ecs;
-   // }
-
-   // public void setEcs(Map<String, Set<String>> ecs) {
-   //       this.ecs = ecs;
-   // }
 
    @Override
    public String toString() {

--- a/src/main/java/uk/gov/companieshouse/servicesdashboardapi/service/github/GitService.java
+++ b/src/main/java/uk/gov/companieshouse/servicesdashboardapi/service/github/GitService.java
@@ -64,7 +64,7 @@ public class GitService {
       this.httpEntity = new HttpEntity<>(headers);
    }
 
-   public String getRepoOwner(String project) {
+   public GitCustomProperty[] getCustomProperties(String project) {
       String customPropEndpoint = String.format("%s/repos/%s/%s/properties/values", api, org, project);
       try {
          ResponseEntity<GitCustomProperty[]> response = restTemplate.exchange(
@@ -74,20 +74,33 @@ public class GitService {
             GitCustomProperty[].class
          );
 
-         GitCustomProperty[] properties = response.getBody();
+         return response.getBody();
+      } catch (Exception e) {
+         ApiLogger.info("Failed to retrieve Git Custom Properties for " + project + ": " + e.getMessage());
+      }
+      return new GitCustomProperty[0];
+   }
 
-         // Filter and find the value of "team-code-owner"
-         if (properties != null) {
-            for (GitCustomProperty property : properties) {
-               if ("team-code-owner".equals(property.getPropertyName())) {
-                  return property.getValue();
-               }
+   public String getRepoOwner(GitCustomProperty[] properties) {
+      if (properties != null) {
+         for (GitCustomProperty property : properties) {
+            if ("team-code-owner".equals(property.getPropertyName())) {
+               return property.getValue();
             }
          }
-      } catch (Exception e) {
-         ApiLogger.info("Failed to retrieve Git Repo Owner " + project + ": " + e.getMessage());
       }
       return "No-Owner";
+   }
+
+   public String getServiceArea(GitCustomProperty[] properties) {
+      if (properties != null) {
+         for (GitCustomProperty property : properties) {
+            if ("service-area".equals(property.getPropertyName())) {
+               return property.getValue();
+            }
+         }
+      }
+      return "No-Service-Area";
    }
 
    public GitInfo getRepoInfo(String project) {
@@ -135,8 +148,13 @@ public class GitService {
             gitInfo.setReleases(releases);
          }
 
+         GitCustomProperty[] properties = getCustomProperties(project);
+
          // add repo's owner
-         gitInfo.setOwner(getRepoOwner(project));
+         gitInfo.setOwner(getRepoOwner(properties));
+
+         // add repo's service area
+         gitInfo.setServiceArea(getServiceArea(properties));
 
       } catch (Exception e) {
          ApiLogger.info("Failed to retrieve Git info for " + gitInfo.getRepo() + ": " + e.getMessage());

--- a/src/main/java/uk/gov/companieshouse/servicesdashboardapi/utils/GitUtils.java
+++ b/src/main/java/uk/gov/companieshouse/servicesdashboardapi/utils/GitUtils.java
@@ -1,0 +1,77 @@
+package uk.gov.companieshouse.servicesdashboardapi.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import uk.gov.companieshouse.servicesdashboardapi.model.github.GitReleaseInfo;
+
+public class GitUtils {
+   private GitUtils() {
+      /* This utility class should not be instantiated */
+   }
+
+    // Filter out the 2 latest releases that are not part of the same release cycle
+   // ex.
+   //    "ecs-service-1.0.22"  |
+   //    "ecs-service-1.0.21"  |
+   //    "ecs-service-1.0.20"  |-----> "ecs-service-1.0.22"
+   //    "4.0.11"              |       "4.0.11"
+   //    "4.0.10"              |
+   //    "ecs-service-1.0.20"  |
+   public static List<GitReleaseInfo> filterReleases(List<GitReleaseInfo> gitReleases) {
+        List<GitReleaseInfo> rel = new ArrayList<GitReleaseInfo>();
+
+        if (gitReleases.isEmpty()) {
+            return rel;
+        }
+
+        GitReleaseInfo firstRelease = gitReleases.get(0);
+        rel.add(firstRelease);
+
+        String regexPattern = buildRegexPattern(firstRelease.getVersion());
+
+        Pattern pattern = Pattern.compile(regexPattern);
+
+        // The built regex are generic and could potentially match more random strings
+        // ex the regex from v1.177.0-rc3" matches something like "Z1876545.22222.564-LL99999"
+        // but that's ok considering that our GitHub releases' format is consistent
+        for (GitReleaseInfo r : gitReleases) {
+            if (!pattern.matcher(r.getVersion()).matches()) {
+                rel.add(r); // Add any optional different format and then break. (We'll then have max 2 releases)
+                break;
+            }
+        }
+        return rel;
+    }
+
+    // build a regex from a provided Release string
+    // ex:
+    // "v1.177.0-rc3"       --> [a-zA-Z]\d+\.\d+\.\d+\-[a-zA-Z][a-zA-Z]\d+])
+    // "5.17.0"             --> \d+\.\d+\.\d+
+    // "ecs-service-1.0.22" --> [a-zA-Z][a-zA-Z][a-zA-Z]\-[a-zA-Z][a-zA-Z][a-zA-Z][a-zA-Z][a-zA-Z][a-zA-Z][a-zA-Z]\-\d+\.\d+\.\d+
+
+    private static String buildRegexPattern(String example) {
+        StringBuilder regex = new StringBuilder();
+        boolean inNumber = false; // Flag to track digit sequences
+
+        for (int i = 0; i < example.length(); i++) {
+            char c = example.charAt(i);
+
+            if (Character.isLetter(c)) {
+                regex.append("[a-zA-Z]");
+                inNumber = false; // Reset number flag
+            } else if (Character.isDigit(c)) {
+                if (!inNumber) { // Only append \d+ for the first digit in a sequence
+                    regex.append("\\d+");
+                    inNumber = true;
+                }
+            } else {
+                regex.append("\\").append(c); // Escape special characters
+                inNumber = false; // Reset number flag
+            }
+        }
+
+        return regex.toString();
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/servicesdashboardapi/utils/GitUtils.java
+++ b/src/main/java/uk/gov/companieshouse/servicesdashboardapi/utils/GitUtils.java
@@ -20,7 +20,7 @@ public class GitUtils {
    //    "4.0.10"              |
    //    "ecs-service-1.0.20"  |
    public static List<GitReleaseInfo> filterReleases(List<GitReleaseInfo> gitReleases) {
-        List<GitReleaseInfo> rel = new ArrayList<GitReleaseInfo>();
+        List<GitReleaseInfo> rel = new ArrayList<>();
 
         if (gitReleases.isEmpty()) {
             return rel;

--- a/src/test/java/uk/gov/companieshouse/servicesdashboardapi/model/github/GitInfoTest.java
+++ b/src/test/java/uk/gov/companieshouse/servicesdashboardapi/model/github/GitInfoTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class GitInfoTest {
@@ -44,6 +43,7 @@ class GitInfoTest {
         assertEquals(1, gitInfo.getReleases().size());
         assertEquals("1.0.0", gitInfo.getReleases().get(0).getVersion());
         assertEquals("2026-01-01", gitInfo.getReleases().get(0).getDate());
+        assertEquals("{r:null l:null o:null sA:null [R:[{v:1.0.0,d:2026-01-01}]]}", gitInfo.toString());
     }
 
     @Test
@@ -54,112 +54,5 @@ class GitInfoTest {
 
         assertNotNull(gitInfo.getReleases());
         assertTrue(gitInfo.getReleases().isEmpty());
-    }
-
-    @Test
-    void shouldKeepFirstReleaseAndFirstDifferentReleaseCycle() {
-        GitInfo gitInfo = new GitInfo();
-
-        GitReleaseInfo first = new GitReleaseInfo();
-        first.setVersion("ecs-service-1.0.22");
-        first.setDate("2026-01-22");
-
-        GitReleaseInfo sameCycleOne = new GitReleaseInfo();
-        sameCycleOne.setVersion("ecs-service-1.0.21");
-        sameCycleOne.setDate("2026-01-21");
-
-        GitReleaseInfo sameCycleTwo = new GitReleaseInfo();
-        sameCycleTwo.setVersion("ecs-service-1.0.20");
-        sameCycleTwo.setDate("2026-01-20");
-
-        GitReleaseInfo differentCycle = new GitReleaseInfo();
-        differentCycle.setVersion("4.0.11");
-        differentCycle.setDate("2025-12-11");
-
-        List<GitReleaseInfo> releases = new ArrayList<>();
-        releases.add(first);
-        releases.add(sameCycleOne);
-        releases.add(sameCycleTwo);
-        releases.add(differentCycle);
-
-        gitInfo.setReleases(releases);
-
-        assertNotNull(gitInfo.getReleases());
-        assertEquals(2, gitInfo.getReleases().size());
-        assertEquals("ecs-service-1.0.22", gitInfo.getReleases().get(0).getVersion());
-        assertEquals("4.0.11", gitInfo.getReleases().get(1).getVersion());
-    }
-
-    @Test
-    void shouldAddFirstNonMatchingReleaseToFilteredList() {
-        GitInfo gitInfo = new GitInfo();
-
-        GitReleaseInfo first = new GitReleaseInfo();
-        first.setVersion("1.2.3");
-        first.setDate("2026-01-23");
-
-        GitReleaseInfo nonMatching = new GitReleaseInfo();
-        nonMatching.setVersion("release-1.2.3");
-        nonMatching.setDate("2026-01-22");
-
-        List<GitReleaseInfo> releases = new ArrayList<>();
-        releases.add(first);
-        releases.add(nonMatching);
-
-        gitInfo.setReleases(releases);
-
-        assertEquals(2, gitInfo.getReleases().size());
-        assertSame(first, gitInfo.getReleases().get(0));
-        assertSame(nonMatching, gitInfo.getReleases().get(1));
-    }
-
-    @Test
-    void shouldOnlyAddOneIfAllMatchingVersions() {
-        GitInfo gitInfo = new GitInfo();
-
-        GitReleaseInfo first = new GitReleaseInfo();
-        first.setVersion("1.2.3");
-        first.setDate("2026-01-23");
-
-        GitReleaseInfo matching = new GitReleaseInfo();
-        matching.setVersion("1.2.3");
-        matching.setDate("2026-01-22");
-
-        List<GitReleaseInfo> releases = new ArrayList<>();
-        releases.add(first);
-        releases.add(matching);
-
-        gitInfo.setReleases(releases);
-
-        assertEquals(1, gitInfo.getReleases().size());
-        assertSame(first, gitInfo.getReleases().get(0));
-    }
-
-    @Test
-    void shouldHandleAlphabeticReleasePatternWhenFiltering() {
-        GitInfo gitInfo = new GitInfo();
-
-        GitReleaseInfo first = new GitReleaseInfo();
-        first.setVersion("abc");
-        first.setDate("2026-01-23");
-
-        GitReleaseInfo matchingAlphabetic = new GitReleaseInfo();
-        matchingAlphabetic.setVersion("xyz");
-        matchingAlphabetic.setDate("2026-01-22");
-
-        GitReleaseInfo differentPattern = new GitReleaseInfo();
-        differentPattern.setVersion("123");
-        differentPattern.setDate("2026-01-21");
-
-        List<GitReleaseInfo> releases = new ArrayList<>();
-        releases.add(first);
-        releases.add(matchingAlphabetic);
-        releases.add(differentPattern);
-
-        gitInfo.setReleases(releases);
-
-        assertEquals(2, gitInfo.getReleases().size());
-        assertSame(first, gitInfo.getReleases().get(0));
-        assertSame(differentPattern, gitInfo.getReleases().get(1));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/servicesdashboardapi/model/github/GitInfoTest.java
+++ b/src/test/java/uk/gov/companieshouse/servicesdashboardapi/model/github/GitInfoTest.java
@@ -1,0 +1,56 @@
+package uk.gov.companieshouse.servicesdashboardapi.model.github;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GitInfoTest {
+
+    @Test
+    void shouldSetAndGetBasicFields() {
+        GitInfo gitInfo = new GitInfo();
+
+        gitInfo.setRepo("https://github.com/companieshouse/services-dashboard-api");
+        gitInfo.setLang("Java");
+        gitInfo.setOwner("team-photon");
+        gitInfo.setServiceArea("Common Components");
+
+        assertEquals("https://github.com/companieshouse/services-dashboard-api", gitInfo.getRepo());
+        assertEquals("Java", gitInfo.getLang());
+        assertEquals("team-photon", gitInfo.getOwner());
+        assertEquals("Common Components", gitInfo.getServiceArea());
+    }
+
+    @Test
+    void shouldSetAndGetReleases() {
+        GitInfo gitInfo = new GitInfo();
+
+        GitReleaseInfo release = new GitReleaseInfo();
+        release.setVersion("1.0.0");
+        release.setDate("2026-01-01");
+
+        List<GitReleaseInfo> releases = new ArrayList<>();
+        releases.add(release);
+
+        gitInfo.setReleases(releases);
+
+        assertNotNull(gitInfo.getReleases());
+        assertEquals(1, gitInfo.getReleases().size());
+        assertEquals("1.0.0", gitInfo.getReleases().get(0).getVersion());
+        assertEquals("2026-01-01", gitInfo.getReleases().get(0).getDate());
+    }
+
+    @Test
+    void shouldSetEmptyReleasesList() {
+        GitInfo gitInfo = new GitInfo();
+
+        gitInfo.setReleases(new ArrayList<>());
+
+        assertNotNull(gitInfo.getReleases());
+        assertTrue(gitInfo.getReleases().isEmpty());
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/servicesdashboardapi/model/github/GitInfoTest.java
+++ b/src/test/java/uk/gov/companieshouse/servicesdashboardapi/model/github/GitInfoTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class GitInfoTest {
@@ -53,5 +54,112 @@ class GitInfoTest {
 
         assertNotNull(gitInfo.getReleases());
         assertTrue(gitInfo.getReleases().isEmpty());
+    }
+
+    @Test
+    void shouldKeepFirstReleaseAndFirstDifferentReleaseCycle() {
+        GitInfo gitInfo = new GitInfo();
+
+        GitReleaseInfo first = new GitReleaseInfo();
+        first.setVersion("ecs-service-1.0.22");
+        first.setDate("2026-01-22");
+
+        GitReleaseInfo sameCycleOne = new GitReleaseInfo();
+        sameCycleOne.setVersion("ecs-service-1.0.21");
+        sameCycleOne.setDate("2026-01-21");
+
+        GitReleaseInfo sameCycleTwo = new GitReleaseInfo();
+        sameCycleTwo.setVersion("ecs-service-1.0.20");
+        sameCycleTwo.setDate("2026-01-20");
+
+        GitReleaseInfo differentCycle = new GitReleaseInfo();
+        differentCycle.setVersion("4.0.11");
+        differentCycle.setDate("2025-12-11");
+
+        List<GitReleaseInfo> releases = new ArrayList<>();
+        releases.add(first);
+        releases.add(sameCycleOne);
+        releases.add(sameCycleTwo);
+        releases.add(differentCycle);
+
+        gitInfo.setReleases(releases);
+
+        assertNotNull(gitInfo.getReleases());
+        assertEquals(2, gitInfo.getReleases().size());
+        assertEquals("ecs-service-1.0.22", gitInfo.getReleases().get(0).getVersion());
+        assertEquals("4.0.11", gitInfo.getReleases().get(1).getVersion());
+    }
+
+    @Test
+    void shouldAddFirstNonMatchingReleaseToFilteredList() {
+        GitInfo gitInfo = new GitInfo();
+
+        GitReleaseInfo first = new GitReleaseInfo();
+        first.setVersion("1.2.3");
+        first.setDate("2026-01-23");
+
+        GitReleaseInfo nonMatching = new GitReleaseInfo();
+        nonMatching.setVersion("release-1.2.3");
+        nonMatching.setDate("2026-01-22");
+
+        List<GitReleaseInfo> releases = new ArrayList<>();
+        releases.add(first);
+        releases.add(nonMatching);
+
+        gitInfo.setReleases(releases);
+
+        assertEquals(2, gitInfo.getReleases().size());
+        assertSame(first, gitInfo.getReleases().get(0));
+        assertSame(nonMatching, gitInfo.getReleases().get(1));
+    }
+
+    @Test
+    void shouldOnlyAddOneIfAllMatchingVersions() {
+        GitInfo gitInfo = new GitInfo();
+
+        GitReleaseInfo first = new GitReleaseInfo();
+        first.setVersion("1.2.3");
+        first.setDate("2026-01-23");
+
+        GitReleaseInfo matching = new GitReleaseInfo();
+        matching.setVersion("1.2.3");
+        matching.setDate("2026-01-22");
+
+        List<GitReleaseInfo> releases = new ArrayList<>();
+        releases.add(first);
+        releases.add(matching);
+
+        gitInfo.setReleases(releases);
+
+        assertEquals(1, gitInfo.getReleases().size());
+        assertSame(first, gitInfo.getReleases().get(0));
+    }
+
+    @Test
+    void shouldHandleAlphabeticReleasePatternWhenFiltering() {
+        GitInfo gitInfo = new GitInfo();
+
+        GitReleaseInfo first = new GitReleaseInfo();
+        first.setVersion("abc");
+        first.setDate("2026-01-23");
+
+        GitReleaseInfo matchingAlphabetic = new GitReleaseInfo();
+        matchingAlphabetic.setVersion("xyz");
+        matchingAlphabetic.setDate("2026-01-22");
+
+        GitReleaseInfo differentPattern = new GitReleaseInfo();
+        differentPattern.setVersion("123");
+        differentPattern.setDate("2026-01-21");
+
+        List<GitReleaseInfo> releases = new ArrayList<>();
+        releases.add(first);
+        releases.add(matchingAlphabetic);
+        releases.add(differentPattern);
+
+        gitInfo.setReleases(releases);
+
+        assertEquals(2, gitInfo.getReleases().size());
+        assertSame(first, gitInfo.getReleases().get(0));
+        assertSame(differentPattern, gitInfo.getReleases().get(1));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/servicesdashboardapi/model/github/GitInfoTest.java
+++ b/src/test/java/uk/gov/companieshouse/servicesdashboardapi/model/github/GitInfoTest.java
@@ -23,6 +23,7 @@ class GitInfoTest {
         assertEquals("Java", gitInfo.getLang());
         assertEquals("team-photon", gitInfo.getOwner());
         assertEquals("Common Components", gitInfo.getServiceArea());
+        assertEquals("{r:https://github.com/companieshouse/services-dashboard-api l:Java o:team-photon sA:Common Components [R:unknown]}", gitInfo.toString());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/servicesdashboardapi/service/github/GitServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/servicesdashboardapi/service/github/GitServiceTest.java
@@ -1,0 +1,44 @@
+package uk.gov.companieshouse.servicesdashboardapi.service.github;
+
+import org.junit.jupiter.api.Test;
+
+import uk.gov.companieshouse.servicesdashboardapi.model.github.GitCustomProperty;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class GitServiceTest {
+
+    @Test
+    void shouldReturnRepoOwnerFromCustomProperties() {
+        GitService gitService = new GitService();
+
+        GitCustomProperty teamOwner = new GitCustomProperty();
+        teamOwner.setPropertyName("team-code-owner");
+        teamOwner.setValue("team-services");
+
+        GitCustomProperty otherProperty = new GitCustomProperty();
+        otherProperty.setPropertyName("service-area");
+        otherProperty.setValue("platform");
+
+        String owner = gitService.getRepoOwner(new GitCustomProperty[] {otherProperty, teamOwner});
+
+        assertEquals("team-services", owner);
+    }
+
+    @Test
+    void shouldReturnServiceAreaFromCustomProperties() {
+        GitService gitService = new GitService();
+
+        GitCustomProperty teamOwner = new GitCustomProperty();
+        teamOwner.setPropertyName("team-code-owner");
+        teamOwner.setValue("team-services");
+
+        GitCustomProperty serviceArea = new GitCustomProperty();
+        serviceArea.setPropertyName("service-area");
+        serviceArea.setValue("platform");
+
+        String area = gitService.getServiceArea(new GitCustomProperty[] {teamOwner, serviceArea});
+
+        assertEquals("platform", area);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/servicesdashboardapi/service/github/GitServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/servicesdashboardapi/service/github/GitServiceTest.java
@@ -1,12 +1,79 @@
 package uk.gov.companieshouse.servicesdashboardapi.service.github;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
 
 import uk.gov.companieshouse.servicesdashboardapi.model.github.GitCustomProperty;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class GitServiceTest {
+
+    @Test
+    void shouldReturnCustomPropertiesFromApiResponse() {
+        GitService gitService = new GitService();
+        RestTemplate restTemplate = mock(RestTemplate.class);
+
+        ReflectionTestUtils.setField(gitService, "api", "https://api.github.com");
+        ReflectionTestUtils.setField(gitService, "org", "companieshouse");
+        ReflectionTestUtils.setField(gitService, "restTemplate", restTemplate);
+        ReflectionTestUtils.setField(gitService, "httpEntity", new HttpEntity<>(null));
+
+        GitCustomProperty owner = new GitCustomProperty();
+        owner.setPropertyName("team-code-owner");
+        owner.setValue("team-photon");
+
+        GitCustomProperty serviceArea = new GitCustomProperty();
+        serviceArea.setPropertyName("service-area");
+        serviceArea.setValue("Common Components");
+
+        GitCustomProperty[] expected = new GitCustomProperty[] {owner, serviceArea};
+        String endpoint = "https://api.github.com/repos/companieshouse/my-service/properties/values";
+
+        when(restTemplate.exchange(
+            eq(endpoint),
+            eq(HttpMethod.GET),
+            any(HttpEntity.class),
+            eq(GitCustomProperty[].class)
+        )).thenReturn(ResponseEntity.ok(expected));
+
+        GitCustomProperty[] result = gitService.getCustomProperties("my-service");
+
+        assertArrayEquals(expected, result);
+    }
+
+    @Test
+    void shouldReturnEmptyArrayWhenCustomPropertiesRequestFails() {
+        GitService gitService = new GitService();
+        RestTemplate restTemplate = mock(RestTemplate.class);
+
+        ReflectionTestUtils.setField(gitService, "api", "https://api.github.com");
+        ReflectionTestUtils.setField(gitService, "org", "companieshouse");
+        ReflectionTestUtils.setField(gitService, "restTemplate", restTemplate);
+        ReflectionTestUtils.setField(gitService, "httpEntity", new HttpEntity<>(null));
+
+        String endpoint = "https://api.github.com/repos/companieshouse/my-service/properties/values";
+
+        when(restTemplate.exchange(
+            eq(endpoint),
+            eq(HttpMethod.GET),
+            any(HttpEntity.class),
+            eq(GitCustomProperty[].class)
+        )).thenThrow(new RuntimeException("GitHub API unavailable"));
+
+        GitCustomProperty[] result = gitService.getCustomProperties("my-service");
+
+        assertEquals(0, result.length);
+    }
 
     @Test
     void shouldReturnRepoOwnerFromCustomProperties() {
@@ -14,15 +81,31 @@ class GitServiceTest {
 
         GitCustomProperty teamOwner = new GitCustomProperty();
         teamOwner.setPropertyName("team-code-owner");
-        teamOwner.setValue("team-services");
+        teamOwner.setValue("team-photon");
 
         GitCustomProperty otherProperty = new GitCustomProperty();
         otherProperty.setPropertyName("service-area");
-        otherProperty.setValue("platform");
+        otherProperty.setValue("Common Components");
 
         String owner = gitService.getRepoOwner(new GitCustomProperty[] {otherProperty, teamOwner});
 
-        assertEquals("team-services", owner);
+        assertEquals("team-photon", owner);
+    }
+
+    @Test
+    void shouldReturnNoOwnerFromCustomProperties() {
+        GitService gitService = new GitService();
+        
+        assertEquals("No-Owner", gitService.getRepoOwner(new GitCustomProperty[0]));
+        assertEquals("No-Owner", gitService.getRepoOwner(null));
+    }
+
+    @Test
+    void shouldReturnNoServiceAreaFromCustomProperties() {
+        GitService gitService = new GitService();
+        
+        assertEquals("No-Service-Area", gitService.getServiceArea(new GitCustomProperty[0]));
+        assertEquals("No-Service-Area", gitService.getServiceArea(null));
     }
 
     @Test
@@ -31,14 +114,14 @@ class GitServiceTest {
 
         GitCustomProperty teamOwner = new GitCustomProperty();
         teamOwner.setPropertyName("team-code-owner");
-        teamOwner.setValue("team-services");
+        teamOwner.setValue("team-photon");
 
         GitCustomProperty serviceArea = new GitCustomProperty();
         serviceArea.setPropertyName("service-area");
-        serviceArea.setValue("platform");
+        serviceArea.setValue("Common Components");
 
         String area = gitService.getServiceArea(new GitCustomProperty[] {teamOwner, serviceArea});
 
-        assertEquals("platform", area);
+        assertEquals("Common Components", area);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/servicesdashboardapi/utils/GitUtilsTest.java
+++ b/src/test/java/uk/gov/companieshouse/servicesdashboardapi/utils/GitUtilsTest.java
@@ -1,0 +1,123 @@
+package uk.gov.companieshouse.servicesdashboardapi.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import uk.gov.companieshouse.servicesdashboardapi.model.github.GitReleaseInfo;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GitUtilsTest {
+
+    @Test
+    void shouldReturnEmptyListWhenGitReleasesIsEmpty() {
+        List<GitReleaseInfo> releases = new ArrayList<>();
+
+        List<GitReleaseInfo> result = GitUtils.filterReleases(releases);
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void shouldHandleAlphabeticReleasePatternWhenFiltering() {
+        GitReleaseInfo first = new GitReleaseInfo();
+        first.setVersion("abc");
+        first.setDate("2026-01-23");
+
+        GitReleaseInfo matchingAlphabetic = new GitReleaseInfo();
+        matchingAlphabetic.setVersion("xyz");
+        matchingAlphabetic.setDate("2026-01-22");
+
+        GitReleaseInfo differentPattern = new GitReleaseInfo();
+        differentPattern.setVersion("123");
+        differentPattern.setDate("2026-01-21");
+
+        List<GitReleaseInfo> releases = new ArrayList<>();
+        releases.add(first);
+        releases.add(matchingAlphabetic);
+        releases.add(differentPattern);
+
+       List<GitReleaseInfo> result = GitUtils.filterReleases(releases);
+
+        assertEquals(2, result.size());
+        assertSame(first, result.get(0));
+        assertSame(differentPattern, result.get(1));
+    }
+
+    @Test
+    void shouldOnlyAddOneIfAllMatchingVersions() {
+        GitReleaseInfo first = new GitReleaseInfo();
+        first.setVersion("1.2.3");
+        first.setDate("2026-01-23");
+
+        GitReleaseInfo matching = new GitReleaseInfo();
+        matching.setVersion("1.2.3");
+        matching.setDate("2026-01-22");
+
+        List<GitReleaseInfo> releases = new ArrayList<>();
+        releases.add(first);
+        releases.add(matching);
+
+        List<GitReleaseInfo> result = GitUtils.filterReleases(releases);
+
+        assertEquals(1, result.size());
+        assertSame(first, result.get(0));
+    }
+
+    @Test
+    void shouldAddFirstNonMatchingReleaseToFilteredList() {
+        GitReleaseInfo first = new GitReleaseInfo();
+        first.setVersion("1.2.3");
+        first.setDate("2026-01-23");
+
+        GitReleaseInfo nonMatching = new GitReleaseInfo();
+        nonMatching.setVersion("release-1.2.3");
+        nonMatching.setDate("2026-01-22");
+
+        List<GitReleaseInfo> releases = new ArrayList<>();
+        releases.add(first);
+        releases.add(nonMatching);
+
+        List<GitReleaseInfo> result = GitUtils.filterReleases(releases);
+
+        assertEquals(2, result.size());
+        assertSame(first, result.get(0));
+        assertSame(nonMatching, result.get(1));
+    }
+
+    @Test
+    void shouldKeepFirstReleaseAndFirstDifferentReleaseCycle() {
+       GitReleaseInfo first = new GitReleaseInfo();
+        first.setVersion("ecs-service-1.0.22");
+        first.setDate("2026-01-22");
+
+        GitReleaseInfo sameCycleOne = new GitReleaseInfo();
+        sameCycleOne.setVersion("ecs-service-1.0.21");
+        sameCycleOne.setDate("2026-01-21");
+
+        GitReleaseInfo sameCycleTwo = new GitReleaseInfo();
+        sameCycleTwo.setVersion("ecs-service-1.0.20");
+        sameCycleTwo.setDate("2026-01-20");
+
+        GitReleaseInfo differentCycle = new GitReleaseInfo();
+        differentCycle.setVersion("4.0.11");
+        differentCycle.setDate("2025-12-11");
+
+        List<GitReleaseInfo> releases = new ArrayList<>();
+        releases.add(first);
+        releases.add(sameCycleOne);
+        releases.add(sameCycleTwo);
+        releases.add(differentCycle);
+
+        List<GitReleaseInfo> result = GitUtils.filterReleases(releases);
+
+        assertEquals(2, result.size());
+        assertEquals("ecs-service-1.0.22", result.get(0).getVersion());
+        assertEquals("4.0.11", result.get(1).getVersion());
+    }
+}


### PR DESCRIPTION
- Pick 'service-owners' custom property from Github info and store it as `serviceArea`
- Remove old commented out code
- Refactor version filtering logic out of GitInfo and into a new GitUtils class
- Unit tests to cover new code